### PR TITLE
Fix angularChainableNames check

### DIFF
--- a/rules/utils/angular-rule.js
+++ b/rules/utils/angular-rule.js
@@ -141,7 +141,7 @@ function angularRule(ruleDefinition) {
                 // angular.module()
                 //         ^^^^^^
                 angularModuleCalls.push(callExpressionNode);
-            } else if (angularChainableNames.indexOf(callee.property.name !== -1) && (angularModuleCalls.indexOf(callee.object) !== -1 || angularChainables.indexOf(callee.object) !== -1)) {
+            } else if (angularChainableNames.indexOf(callee.property.name) !== -1 && (angularModuleCalls.indexOf(callee.object) !== -1 || angularChainables.indexOf(callee.object) !== -1)) {
                 // angular.module().factory().controller()
                 //                  ^^^^^^^   ^^^^^^^^^^
                 angularChainables.push(callExpressionNode);


### PR DESCRIPTION
This conditional was always `true` because `(name !== -1)` is always `true` and thus `angularChainableNames.indexOf(true)` is always `true`