### PR TITLE
Implement arguments check in checkArgumentPositionInFunction()

### DIFF
--- a/rules/one-dependency-per-line.js
+++ b/rules/one-dependency-per-line.js
@@ -22,7 +22,7 @@ module.exports = {
         var angularObjectList = ['animation', 'config', 'constant', 'controller', 'directive', 'factory', 'filter', 'provider', 'service', 'value', 'decorator'];
 
         function checkArgumentPositionInFunction(node) {
-            if (!node.params || node.params.length < 2) {
+            if (!node || !node.params || node.params.length < 2) {
                 return;
             }
 


### PR DESCRIPTION
I was experiencing the error below when trying to run eslint on my project.

I found that at one point the function `checkArgumentPositionInFunction()` was being called without any arguments. I don't understand why that would happen in the first place, but I decided that it could not hurt to implement a check and exit the function if no arguments where provided.

Let me know if you want to debug the root cause and need more info.

Error message:
```
Cannot read property 'params' of undefined
TypeError: Cannot read property 'params' of undefined
    at checkArgumentPositionInFunction (/Users/learningbank/Projects/app/node_modules/eslint-plugin-angular/rules/one-dependency-per-line.js:26:23)
    at /Users/learningbank/Projects/app/node_modules/eslint-plugin-angular/rules/one-dependency-per-line.js:59:21
    at Array.forEach (<anonymous>)
    at checkArgumentPositionArrayExpression (/Users/learningbank/Projects/app/node_modules/eslint-plugin-angular/rules/one-dependency-per-line.js:50:32)
    at CallExpression (/Users/learningbank/Projects/app/node_modules/eslint-plugin-angular/rules/one-dependency-per-line.js:135:28)
    at listeners.(anonymous function).forEach.listener (/Users/learningbank/Projects/app/node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/learningbank/Projects/app/node_modules/eslint/lib/util/safe-emitter.js:47:38)
    at NodeEventGenerator.applySelector (/Users/learningbank/Projects/app/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/Users/learningbank/Projects/app/node_modules/eslint/lib/util/node-event-generator.js:280:22)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! learningbank-frontend@1.0.0 eslint: `eslint src/**`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the learningbank-frontend@1.0.0 eslint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/learningbank/.npm/_logs/2019-02-19T15_03_26_043Z-debug.log
```