### PR TITLE
docs(package): remove angular keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "keywords": [
         "eslint",
         "eslintplugin",
-        "angular",
         "angularjs"
     ],
     "dependencies": {}


### PR DESCRIPTION
Having the `angular` keyword in this AngularJS NPM package may be misleading for people who are looking for Angular specific packages.