### PR TITLE
Fixed issue due to arrow function syntax

### DIFF
--- a/rules/prefer-component.js
+++ b/rules/prefer-component.js
@@ -42,7 +42,18 @@ module.exports = {
                 var body = fnNode.body.body ? fnNode.body.body : [fnNode.body];
 
                 body.forEach(function(statement) {
-                    if (statement.type === 'ReturnStatement' && !potentialReplaceNodes[statement.argument.name || '']) {
+                    var potentialNodes;
+                    if (statement.argument) {
+                        potentialNodes = potentialReplaceNodes[statement.argument.name || ''];
+                    } else {
+                        potentialNodes = potentialReplaceNodes[''];
+                    }
+
+                    if (potentialNodes) {
+                        return;
+                    }
+
+                    if (statement.type === 'ReturnStatement' || statement.type === 'ObjectExpression' && statement.parent.type === 'ArrowFunctionExpression') {
                         context.report(statement, 'Directive should be implemented with the component method.');
                     }
                 });
@@ -78,6 +89,11 @@ module.exports = {
 
                 // report directly if object is part of a return statement and inside a directive body
                 if (objectExpressionParent.type === 'ReturnStatement') {
+                    addPotentialLinkNode('', node);
+                }
+
+                // report directly if object is part of a arrow function and inside a directive body
+                if (objectExpressionParent.type === 'ArrowFunctionExpression') {
                     addPotentialLinkNode('', node);
                 }
             }

--- a/rules/prefer-component.js
+++ b/rules/prefer-component.js
@@ -38,7 +38,10 @@ module.exports = {
                 if (!fnNode || !fnNode.body) {
                     return;
                 }
-                fnNode.body.body.forEach(function(statement) {
+
+                var body = fnNode.body.body ? fnNode.body.body : [fnNode.body];
+
+                body.forEach(function(statement) {
                     if (statement.type === 'ReturnStatement' && !potentialReplaceNodes[statement.argument.name || '']) {
                         context.report(statement, 'Directive should be implemented with the component method.');
                     }

--- a/test/prefer-component.js
+++ b/test/prefer-component.js
@@ -12,7 +12,11 @@ var commonFalsePositives = require('./utils/commonFalsePositives');
 // Tests
 // ------------------------------------------------------------------------------
 
-var eslintTester = new RuleTester();
+var eslintTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 6
+    }
+});
 eslintTester.run('prefer-component', rule, {
     valid: [
         'angular.module("").directive("")',
@@ -32,7 +36,8 @@ eslintTester.run('prefer-component', rule, {
         'angular.module("").directive("", function() { var def = {link: function(){}}; return def; })',
         'angular.module("").directive("", function() { var def = {}; def.link = function(){}; return def; })',
         'angular.module("").directive("", directive); function directive() { return {link:function(){}} };',
-        'angular.module("").directive("", directive); function directive() { var def = {}; def.link = function(){}; return def; };'
+        'angular.module("").directive("", directive); function directive() { var def = {}; def.link = function(){}; return def; };',
+        'angular.module("").directive("", () => ({restrict: "A"}))'
     ].concat(commonFalsePositives),
     invalid: [
         {
@@ -41,6 +46,10 @@ eslintTester.run('prefer-component', rule, {
         },
         {
             code: 'angular.module("").directive("", function() {return {restrict:"E"}})',
+            errors: [{message: 'Directive should be implemented with the component method.'}]
+        },
+        {
+            code: 'angular.module("").directive("", () => ({restrict:"E"}))',
             errors: [{message: 'Directive should be implemented with the component method.'}]
         },
         {


### PR DESCRIPTION
Error caused by following syntax:
```javascript
        directive("myDirective", () => ({
            restrict: "A",
            controller: MyCtrl,
        }));
```

Similar to changes made [here](https://github.com/EmmanuelDemey/eslint-plugin-angular/commit/ec3b337f2bc80b488fc52482a4113cd421b32005)

Two tests added:
* Valid: `angular.module("").directive("", () => ({restrict: "A"}))`
* Invalid: `angular.module("").directive("", () => ({restrict: "E"}))`

All tests pass.

Travis CI checks will fail as I an behind a proxy and yarn.lock contains proxy links to dependencies. I'll attempt to rebuild it when I'm not at work.