### PR TITLE
Adjusting on-watch rule to avoid false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
  * [no-inline-template](docs/rules/no-inline-template.md) - disallow the use of inline templates
  * [no-run-logic](docs/rules/no-run-logic.md) - keep run functions clean and simple ([y171](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#style-y171))
  * [no-services](docs/rules/no-services.md) - disallow DI of specified services for other angular components (`$http` for controllers, filters and directives)
- * [on-watch](docs/rules/on-watch.md) - require `$on` and `$watch` deregistration callbacks to be saved in a variable
+ * [on-watch](docs/rules/on-watch.md) - require `$on` and `$watch` deregistration callbacks not to be ignored
  * [prefer-component](docs/rules/prefer-component.md) - 
 
 ### Deprecated Angular Features

--- a/docs/rules/on-watch.md
+++ b/docs/rules/on-watch.md
@@ -1,8 +1,9 @@
 <!-- WARNING: Generated documentation. Edit docs and examples in the rule and examples file ('rules/on-watch.js', 'examples/on-watch.js'). -->
 
-# on-watch - require `$on` and `$watch` deregistration callbacks to be saved in a variable
+# on-watch - require `$on` and `$watch` deregistration callbacks not to be ignored
 
-Watch and On methods on the scope object should be assigned to a variable, in order to be deleted in a $destroy event handler
+Deregistration functions returned by Watch and On methods on the scope object should not be ignored, in order to be deleted in a $destroy event handler.
+They should be assigned to a variable, returned from a function, put in an array or passed to a function as an argument.
 
 **Rule based on Angular 1.x**
 
@@ -15,7 +16,7 @@ The following patterns are considered problems;
     // invalid
     $rootScope.$on('event', function () {
         // ...
-    }); // error: The "$on" call should be assigned to a variable, in order to be destroyed during the $destroy event
+    }); // error: The deregistration function returned by "$on" call call should not be ignored
 
 The following patterns are **not** considered problems;
 
@@ -27,9 +28,27 @@ The following patterns are **not** considered problems;
     });
 
     // valid
-    var unregister = $rootScope.$on('event', function () {
+    var deregister = $rootScope.$on('event', function () {
         // ...
     });
+
+    // valid
+    function watchLocalVariable(callback) {
+        return $rootScope.$watch(function() {
+            return watchLocalVariable;
+        }, callback);
+    }
+
+    // valid
+    var deregisterFns = [
+        $rootScope.$on('event', eventHandler),
+        $rootScope.$watch('expression', watcherHandler)
+    ];
+
+    // valid
+    deregisterFns.push($rootScope.$on('event', function() {
+        // ...
+    }));
 
 ## Version
 

--- a/examples/on-watch.js
+++ b/examples/on-watch.js
@@ -4,11 +4,29 @@ $scope.$on('event', function () {
 });
 
 // example - valid: true
-var unregister = $rootScope.$on('event', function () {
+var deregister = $rootScope.$on('event', function () {
     // ...
 });
 
-// example - valid: false, errorMessage: "The \"$on\" call should be assigned to a variable, in order to be destroyed during the $destroy event"
+// example - valid: true
+function watchLocalVariable(callback) {
+    return $rootScope.$watch(function() {
+        return watchLocalVariable;
+    }, callback);
+}
+
+// example - valid: true
+var deregisterFns = [
+    $rootScope.$on('event', eventHandler),
+    $rootScope.$watch('expression', watcherHandler)
+];
+
+// example - valid: true
+deregisterFns.push($rootScope.$on('event', function() {
+    // ...
+}));
+
+// example - valid: false, errorMessage: "The deregistration function returned by \"$on\" call call should not be ignored"
 $rootScope.$on('event', function () {
     // ...
 });

--- a/test/on-watch.js
+++ b/test/on-watch.js
@@ -35,13 +35,16 @@ eslintTester.run('on-watch', rule, {
 
         // false positive check
         '$on()',
+        'function watchSomething() {return $rootScope.$watch()}',
+        'var variable = [$rootScope.$on(), $rootScope.$watch()]',
+        'var variable = []; variable.push($rootScope.$watch());',
 
         // uncovered edgecase
         '$scope["$on"]()'
 
     ].concat(commonFalsePositives),
     invalid: [
-        {code: '$rootScope.$on()', errors: [{message: 'The "$on" call should be assigned to a variable, in order to be destroyed during the $destroy event'}]},
-        {code: '$rootScope.$watch()', errors: [{message: 'The "$watch" call should be assigned to a variable, in order to be destroyed during the $destroy event'}]}
+        {code: '$rootScope.$on()', errors: [{message: 'The deregistration function returned by "$on" call should not be ignored'}]},
+        {code: '$rootScope.$watch()', errors: [{message: 'The deregistration function returned by "$watch" call should not be ignored'}]}
     ]
 });


### PR DESCRIPTION
I was getting some false positives from the **on-watch** rule when storing the $watch or $on deregistration functions in an array or returning them from a function.

I propose not reporting any problems in these cases.