### PR TITLE
For rule 'di' add allowCamelCaseMatch option

### DIFF
--- a/docs/rules/di.md
+++ b/docs/rules/di.md
@@ -54,6 +54,24 @@ The following patterns are **not** considered problems when configured `"array"`
         // ...
     }]);
 
+The following patterns are considered problems when configured `"array"` and `{"allowCamelCaseMatch":true}`:
+
+    /*eslint angular/di: [2,"array",{"allowCamelCaseMatch":true}]*/
+
+    // invalid
+    angular.module('myModule').factory('myService', ['$http', '$log', 'AnotherService', function ($log, $http, anotherservice) {
+        // ...
+    }]); // error: You have an error in your DI configuration. Each items of the array should match exactly one function parameter
+
+The following patterns are **not** considered problems when configured `"array"` and `{"allowCamelCaseMatch":true}`:
+
+    /*eslint angular/di: [2,"array",{"allowCamelCaseMatch":true}]*/
+
+    // valid
+    angular.module('myModule').factory('myService', ['$http', '$log', 'AnotherService', function ($http, $log, anotherService) {
+        // ...
+    }]);
+
 The following patterns are **not** considered problems when configured `"array"` and `{"matchNames":false}`:
 
     /*eslint angular/di: [2,"array",{"matchNames":false}]*/
@@ -95,6 +113,28 @@ The following patterns are **not** considered problems when configured `"$inject
     // valid
     angular.module('myModule').factory('myService', myServiceFn);
     myServiceFn.$inject=['$http', '$log', 'anotherService'];
+    function myServiceFn($http, $log, anotherService) {
+        // ...
+    }
+
+The following patterns are considered problems when configured `"$inject"` and `{"allowCamelCaseMatch":true}`:
+
+    /*eslint angular/di: [2,"$inject",{"allowCamelCaseMatch":true}]*/
+
+    // invalid
+    angular.module('myModule').factory('myService', myServiceFn);
+    myServiceFn.$inject=['$log', '$http', 'AnotherService'];
+    function myServiceFn($http, $log, 'anotherservice') {
+        // ...
+    } // error: You have an error in your DI configuration. Each items of the array should match exactly one function parameter
+
+The following patterns are **not** considered problems when configured `"$inject"` and `{"allowCamelCaseMatch":true}`:
+
+    /*eslint angular/di: [2,"$inject",{"allowCamelCaseMatch":true}]*/
+
+    // valid
+    angular.module('myModule').factory('myService', myServiceFn);
+    myServiceFn.$inject=['$http', '$log', 'AnotherService'];
     function myServiceFn($http, $log, anotherService) {
         // ...
     }

--- a/docs/rules/di.md
+++ b/docs/rules/di.md
@@ -54,18 +54,18 @@ The following patterns are **not** considered problems when configured `"array"`
         // ...
     }]);
 
-The following patterns are considered problems when configured `"array"` and `{"allowCamelCaseMatch":true}`:
+The following patterns are considered problems when configured `"array"` and `{"matchNames":true,"allowCamelCaseMatch":true}`:
 
-    /*eslint angular/di: [2,"array",{"allowCamelCaseMatch":true}]*/
+    /*eslint angular/di: [2,"array",{"matchNames":true,"allowCamelCaseMatch":true}]*/
 
     // invalid
     angular.module('myModule').factory('myService', ['$http', '$log', 'AnotherService', function ($log, $http, anotherservice) {
         // ...
     }]); // error: You have an error in your DI configuration. Each items of the array should match exactly one function parameter
 
-The following patterns are **not** considered problems when configured `"array"` and `{"allowCamelCaseMatch":true}`:
+The following patterns are **not** considered problems when configured `"array"` and `{"matchNames":true,"allowCamelCaseMatch":true}`:
 
-    /*eslint angular/di: [2,"array",{"allowCamelCaseMatch":true}]*/
+    /*eslint angular/di: [2,"array",{"matchNames":true,"allowCamelCaseMatch":true}]*/
 
     // valid
     angular.module('myModule').factory('myService', ['$http', '$log', 'AnotherService', function ($http, $log, anotherService) {
@@ -117,9 +117,9 @@ The following patterns are **not** considered problems when configured `"$inject
         // ...
     }
 
-The following patterns are considered problems when configured `"$inject"` and `{"allowCamelCaseMatch":true}`:
+The following patterns are considered problems when configured `"$inject"` and `{"matchNames":true,"allowCamelCaseMatch":true}`:
 
-    /*eslint angular/di: [2,"$inject",{"allowCamelCaseMatch":true}]*/
+    /*eslint angular/di: [2,"$inject",{"matchNames":true,"allowCamelCaseMatch":true}]*/
 
     // invalid
     angular.module('myModule').factory('myService', myServiceFn);
@@ -128,9 +128,9 @@ The following patterns are considered problems when configured `"$inject"` and `
         // ...
     } // error: You have an error in your DI configuration. Each items of the array should match exactly one function parameter
 
-The following patterns are **not** considered problems when configured `"$inject"` and `{"allowCamelCaseMatch":true}`:
+The following patterns are **not** considered problems when configured `"$inject"` and `{"matchNames":true,"allowCamelCaseMatch":true}`:
 
-    /*eslint angular/di: [2,"$inject",{"allowCamelCaseMatch":true}]*/
+    /*eslint angular/di: [2,"$inject",{"matchNames":true,"allowCamelCaseMatch":true}]*/
 
     // valid
     angular.module('myModule').factory('myService', myServiceFn);

--- a/examples/di.js
+++ b/examples/di.js
@@ -13,6 +13,10 @@ angular.module('myModule').factory('myService', ['$http', '$log', 'anotherServic
     // ...
 }]);
 
+// example - valid: true, options: ["array", {matchNames: true, allowCamelCaseMatch: true}]
+angular.module('myModule').factory('myService', ['$http', '$log', 'AnotherService', function ($http, $log, anotherService) {
+    // ...
+}]);
 // example - valid: true, options: ["array", {matchNames: false}]
 angular.module('myModule').factory('myService', ['eslintService', function (service) {
     // ...
@@ -21,6 +25,13 @@ angular.module('myModule').factory('myService', ['eslintService', function (serv
 // example - valid: true, options: ["$inject"]
 angular.module('myModule').factory('myService', myServiceFn);
 myServiceFn.$inject=['$http', '$log', 'anotherService'];
+function myServiceFn($http, $log, anotherService) {
+    // ...
+}
+
+// example - valid: true, options: ["$inject", {matchNames: true, allowCamelCaseMatch: true}]
+angular.module('myModule').factory('myService', myServiceFn);
+myServiceFn.$inject=['$http', '$log', 'AnotherService'];
 function myServiceFn($http, $log, anotherService) {
     // ...
 }
@@ -39,6 +50,11 @@ angular.module('myModule').factory('myService', ['$http', '$log', 'anotherServic
 
 // example - valid: false, options: ["array"], errorMessage: "You have an error in your DI configuration. Each items of the array should match exactly one function parameter"
 angular.module('myModule').factory('myService', ['$http', '$log', function ($log, $http) {
+    // ...
+}]);
+
+// example - valid: false, options: ["array", {matchNames: true, allowCamelCaseMatch: true}], errorMessage: "You have an error in your DI configuration. Each items of the array should match exactly one function parameter"
+angular.module('myModule').factory('myService', ['$http', '$log', 'AnotherService', function ($log, $http, anotherservice) {
     // ...
 }]);
 
@@ -65,5 +81,12 @@ function myServiceFn($http, $log, anotherService) {
 angular.module('myModule').factory('myService', myServiceFn);
 myServiceFn.$inject=['$log', '$http'];
 function myServiceFn($http, $log) {
+    // ...
+}
+
+// example - valid: false, options: ["$inject", {matchNames: true, allowCamelCaseMatch: true}], errorMessage: "You have an error in your DI configuration. Each items of the array should match exactly one function parameter"
+angular.module('myModule').factory('myService', myServiceFn);
+myServiceFn.$inject=['$log', '$http', 'AnotherService'];
+function myServiceFn($http, $log, 'anotherservice') {
     // ...
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-angular",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/highlight": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       }
     },
     "abbrev": {
@@ -48,10 +48,10 @@
       "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "align-text": {
@@ -59,10 +59,11 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "kind-of": {
@@ -70,8 +71,9 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -88,7 +90,7 @@
       "integrity": "sha512-yopkAU0ZD/WQ56Tms3xLn6jRuX3SyUMAVi0FdmDIbmmnHW3jHiI1sQFdUl3gfVddjnrsP3Y6ywFKvCRopvoVIA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "0.1.0"
+        "ansi-wrap": "^0.1.0"
       }
     },
     "ansi-cyan": {
@@ -136,7 +138,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "ansi-wrap": {
@@ -151,8 +153,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.5",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "append-buffer": {
@@ -161,7 +163,7 @@
       "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
       "dev": true,
       "requires": {
-        "buffer-equal": "1.0.0"
+        "buffer-equal": "^1.0.0"
       }
     },
     "archy": {
@@ -176,7 +178,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -191,7 +193,7 @@
       "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
       "dev": true,
       "requires": {
-        "make-iterator": "1.0.0"
+        "make-iterator": "^1.0.0"
       }
     },
     "arr-flatten": {
@@ -206,7 +208,7 @@
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "dev": true,
       "requires": {
-        "make-iterator": "1.0.0"
+        "make-iterator": "^1.0.0"
       }
     },
     "arr-union": {
@@ -233,8 +235,8 @@
       "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
       "dev": true,
       "requires": {
-        "array-slice": "1.1.0",
-        "is-number": "4.0.0"
+        "array-slice": "^1.0.0",
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -251,7 +253,7 @@
       "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -274,9 +276,9 @@
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
       "dev": true,
       "requires": {
-        "default-compare": "1.0.0",
-        "get-value": "2.0.6",
-        "kind-of": "5.1.0"
+        "default-compare": "^1.0.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^5.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -299,7 +301,7 @@
       "integrity": "sha1-uG302tz8I2pKQE8CR5QLf3OzYT4=",
       "dev": true,
       "requires": {
-        "array-flatten": "2.1.1"
+        "array-flatten": ">= 0.0.2"
       }
     },
     "asn1": {
@@ -308,7 +310,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
@@ -347,10 +349,10 @@
       "integrity": "sha512-mxc+yISkb0vjsuvG3dJCIZXzRWjKndQ9Zo9zNDJ1K2wh9eP0E0oGmOWm+4cFOvW4dA0tGFImTW5tQJHCtn1kIQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0",
-        "process-nextick-args": "1.0.7",
-        "stream-exhaust": "1.0.2"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.2",
+        "process-nextick-args": "^1.0.7",
+        "stream-exhaust": "^1.0.1"
       }
     },
     "async-each": {
@@ -365,7 +367,7 @@
       "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
       "dev": true,
       "requires": {
-        "async-done": "1.2.4"
+        "async-done": "^1.2.2"
       }
     },
     "asynckit": {
@@ -398,15 +400,15 @@
       "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
       "dev": true,
       "requires": {
-        "arr-filter": "1.1.2",
-        "arr-flatten": "1.1.0",
-        "arr-map": "2.0.2",
-        "array-each": "1.0.1",
-        "array-initial": "1.1.0",
-        "array-last": "1.3.0",
-        "async-done": "1.2.4",
-        "async-settle": "1.0.0",
-        "now-and-later": "2.0.0"
+        "arr-filter": "^1.1.1",
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "array-each": "^1.0.0",
+        "array-initial": "^1.0.0",
+        "array-last": "^1.1.1",
+        "async-done": "^1.2.2",
+        "async-settle": "^1.0.0",
+        "now-and-later": "^2.0.0"
       }
     },
     "balanced-match": {
@@ -421,13 +423,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.0",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       }
     },
     "bcrypt-pbkdf": {
@@ -436,7 +438,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary-extensions": {
@@ -451,7 +453,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -461,17 +463,17 @@
       "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.1",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.1"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       }
     },
     "browser-stdout": {
@@ -498,15 +500,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "callsites": {
@@ -535,8 +537,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -554,12 +556,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chai-spies": {
@@ -574,9 +576,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -597,17 +599,17 @@
       "integrity": "sha512-OgXCNv2U6TnG04D3tth0gsvdbV4zdbxFG3sYUqcoQMoEFVd1j1pZR6TZ8iknC45o9IJ6PeQI/J6wT/+cHcniAw==",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.1",
-        "braces": "2.3.0",
-        "fsevents": "1.1.3",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.0",
-        "normalize-path": "2.1.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "class-utils": {
@@ -616,10 +618,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -628,7 +630,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -637,7 +639,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -646,7 +648,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -657,7 +659,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -666,7 +668,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -677,9 +679,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -696,7 +698,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -712,8 +714,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -750,9 +752,9 @@
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^1.0.6",
+        "through2": "^2.0.1"
       }
     },
     "code-point-at": {
@@ -767,9 +769,9 @@
       "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
       "dev": true,
       "requires": {
-        "arr-map": "2.0.2",
-        "for-own": "1.0.0",
-        "make-iterator": "1.0.0"
+        "arr-map": "^2.0.2",
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
       }
     },
     "collection-visit": {
@@ -778,8 +780,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -809,7 +811,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "component-emitter": {
@@ -830,9 +832,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "convert-source-map": {
@@ -853,8 +855,8 @@
       "integrity": "sha1-Zl/DIEbKhKiYq6o8WUXn8kjMugA=",
       "dev": true,
       "requires": {
-        "each-props": "1.3.1",
-        "is-plain-object": "2.0.4"
+        "each-props": "^1.3.0",
+        "is-plain-object": "^2.0.1"
       }
     },
     "core-util-is": {
@@ -869,12 +871,12 @@
       "integrity": "sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==",
       "dev": true,
       "requires": {
-        "growl": "1.10.5",
-        "js-yaml": "3.12.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.7",
-        "minimist": "1.2.0",
-        "request": "2.88.0"
+        "growl": "~> 1.10.0",
+        "js-yaml": "^3.11.0",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.0",
+        "request": "^2.86.0"
       },
       "dependencies": {
         "js-yaml": {
@@ -883,8 +885,8 @@
           "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         }
       }
@@ -895,11 +897,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "d": {
@@ -908,7 +910,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "^0.10.9"
       }
     },
     "dargs": {
@@ -923,7 +925,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -953,7 +955,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -968,7 +970,7 @@
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "dev": true,
       "requires": {
-        "kind-of": "5.1.0"
+        "kind-of": "^5.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -991,8 +993,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -1001,7 +1003,7 @@
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2"
+        "is-descriptor": "^1.0.0"
       }
     },
     "delayed-stream": {
@@ -1028,7 +1030,7 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "duplexify": {
@@ -1037,10 +1039,10 @@
       "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "each-props": {
@@ -1049,8 +1051,8 @@
       "integrity": "sha1-/BOPUeOid0KG1IWOAtbn3kYt4Vg=",
       "dev": true,
       "requires": {
-        "is-plain-object": "2.0.4",
-        "object.defaults": "1.1.0"
+        "is-plain-object": "^2.0.1",
+        "object.defaults": "^1.1.0"
       }
     },
     "ecc-jsbn": {
@@ -1059,8 +1061,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "emoji-regex": {
@@ -1075,7 +1077,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "error-ex": {
@@ -1084,7 +1086,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -1093,12 +1095,12 @@
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.2.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4",
-        "object-keys": "1.1.1"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       },
       "dependencies": {
         "object-keys": {
@@ -1115,9 +1117,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.2"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es5-ext": {
@@ -1126,8 +1128,8 @@
       "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -1136,9 +1138,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-symbol": {
@@ -1147,8 +1149,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -1157,10 +1159,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1175,11 +1177,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "esprima": {
@@ -1201,7 +1203,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1212,42 +1214,42 @@
       "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "ajv": "6.9.1",
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "debug": "4.1.1",
-        "doctrine": "3.0.0",
-        "eslint-scope": "4.0.3",
-        "eslint-utils": "1.3.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "5.0.1",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "5.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.12.0",
-        "ignore": "4.0.6",
-        "import-fresh": "3.0.0",
-        "imurmurhash": "0.1.4",
-        "inquirer": "6.3.1",
-        "js-yaml": "3.13.1",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "progress": "2.0.3",
-        "regexpp": "2.0.1",
-        "semver": "5.7.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "5.2.3",
-        "text-table": "0.2.0"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.13.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "debug": {
@@ -1256,7 +1258,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "js-yaml": {
@@ -1265,8 +1267,8 @@
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "lodash": {
@@ -1295,8 +1297,8 @@
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -1317,9 +1319,9 @@
       "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
       "dev": true,
       "requires": {
-        "acorn": "6.1.1",
-        "acorn-jsx": "5.0.1",
-        "eslint-visitor-keys": "1.0.0"
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
@@ -1334,7 +1336,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -1343,7 +1345,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -1364,13 +1366,13 @@
       "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -1379,13 +1381,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -1403,7 +1405,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1412,7 +1414,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -1421,7 +1423,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -1432,7 +1434,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -1441,7 +1443,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -1452,9 +1454,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -1471,7 +1473,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "extend": {
@@ -1486,7 +1488,7 @@
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "external-editor": {
@@ -1495,9 +1497,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -1506,14 +1508,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "extract-comments": {
@@ -1522,7 +1524,7 @@
       "integrity": "sha1-HF3sFzAHLFsM36VVfl9X9pJ3/DQ=",
       "dev": true,
       "requires": {
-        "is-whitespace": "0.3.0"
+        "is-whitespace": "^0.3.0"
       }
     },
     "extsprintf": {
@@ -1537,9 +1539,9 @@
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "ansi-gray": "0.1.1",
-        "color-support": "1.1.3",
-        "time-stamp": "1.1.0"
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "time-stamp": "^1.0.0"
       }
     },
     "fast-deep-equal": {
@@ -1566,7 +1568,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1575,7 +1577,7 @@
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "2.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "fill-range": {
@@ -1584,10 +1586,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       }
     },
     "find-up": {
@@ -1596,8 +1598,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -1606,10 +1608,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "1.0.0",
-        "is-glob": "3.1.0",
-        "micromatch": "3.1.5",
-        "resolve-dir": "1.0.1"
+        "detect-file": "^1.0.0",
+        "is-glob": "^3.1.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
       },
       "dependencies": {
         "is-glob": {
@@ -1618,7 +1620,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -1629,11 +1631,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "is-plain-object": "2.0.4",
-        "object.defaults": "1.1.0",
-        "object.pick": "1.3.0",
-        "parse-filepath": "1.0.2"
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
       }
     },
     "flagged-respawn": {
@@ -1648,7 +1650,7 @@
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "dev": true,
       "requires": {
-        "is-buffer": "2.0.3"
+        "is-buffer": "~2.0.3"
       },
       "dependencies": {
         "is-buffer": {
@@ -1665,7 +1667,7 @@
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "flatted": "2.0.0",
+        "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
@@ -1682,8 +1684,8 @@
       "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "for-in": {
@@ -1698,7 +1700,7 @@
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -1719,9 +1721,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.7",
-        "mime-types": "2.1.22"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -1730,7 +1732,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fs-mkdirp-stream": {
@@ -1739,8 +1741,8 @@
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "through2": "2.0.3"
+        "graceful-fs": "^4.1.11",
+        "through2": "^2.0.3"
       }
     },
     "fs.realpath": {
@@ -1756,8 +1758,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.9.2",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -1779,7 +1781,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -1830,7 +1833,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -1845,6 +1849,7 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "2.0.3"
           }
@@ -1853,6 +1858,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -1861,6 +1867,7 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
@@ -1869,7 +1876,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -1886,12 +1894,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
@@ -1899,22 +1909,26 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -1954,7 +1968,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -1986,7 +2001,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -2008,12 +2024,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -2069,6 +2087,7 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -2081,7 +2100,8 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -2109,6 +2129,7 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -2119,7 +2140,8 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -2136,6 +2158,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -2144,7 +2167,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -2156,6 +2180,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -2169,7 +2194,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -2242,12 +2268,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "1.27.0"
           }
@@ -2256,6 +2284,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "1.1.7"
           }
@@ -2263,12 +2292,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2323,7 +2354,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -2341,6 +2373,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -2370,7 +2403,8 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -2381,7 +2415,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2419,6 +2454,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
@@ -2463,6 +2499,7 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "7.1.2"
           }
@@ -2470,7 +2507,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2494,6 +2532,7 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -2527,6 +2566,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -2537,6 +2577,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
@@ -2551,6 +2592,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -2565,6 +2607,7 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -2620,7 +2663,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -2649,7 +2693,8 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2695,7 +2740,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gfm-code-block-regex": {
@@ -2710,7 +2755,7 @@
       "integrity": "sha1-KZnYFIxFG4ZjLHH6bevhFe4HH/4=",
       "dev": true,
       "requires": {
-        "gfm-code-block-regex": "0.2.3"
+        "gfm-code-block-regex": "^0.2.1"
       }
     },
     "glob": {
@@ -2719,12 +2764,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -2733,8 +2778,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -2743,7 +2788,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -2754,16 +2799,16 @@
       "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "glob": "7.1.2",
-        "glob-parent": "3.1.0",
-        "is-negated-glob": "1.0.0",
-        "ordered-read-streams": "1.0.1",
-        "pumpify": "1.4.0",
-        "readable-stream": "2.3.3",
-        "remove-trailing-separator": "1.1.0",
-        "to-absolute-glob": "2.0.2",
-        "unique-stream": "2.2.1"
+        "extend": "^3.0.0",
+        "glob": "^7.1.1",
+        "glob-parent": "^3.1.0",
+        "is-negated-glob": "^1.0.0",
+        "ordered-read-streams": "^1.0.0",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.1.5",
+        "remove-trailing-separator": "^1.0.1",
+        "to-absolute-glob": "^2.0.0",
+        "unique-stream": "^2.0.2"
       }
     },
     "global-modules": {
@@ -2772,9 +2817,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.1",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -2783,11 +2828,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.1",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -2802,7 +2847,7 @@
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -2823,10 +2868,10 @@
       "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
       "dev": true,
       "requires": {
-        "glob-watcher": "5.0.3",
-        "gulp-cli": "2.2.0",
-        "undertaker": "1.2.1",
-        "vinyl-fs": "3.0.1"
+        "glob-watcher": "^5.0.3",
+        "gulp-cli": "^2.2.0",
+        "undertaker": "^1.2.1",
+        "vinyl-fs": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2841,9 +2886,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "findup-sync": {
@@ -2852,10 +2897,10 @@
           "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
           "dev": true,
           "requires": {
-            "detect-file": "1.0.0",
-            "is-glob": "4.0.0",
-            "micromatch": "3.1.5",
-            "resolve-dir": "1.0.1"
+            "detect-file": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
           }
         },
         "glob-watcher": {
@@ -2864,12 +2909,12 @@
           "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-done": "1.2.4",
-            "chokidar": "2.0.0",
-            "is-negated-glob": "1.0.0",
-            "just-debounce": "1.0.0",
-            "object.defaults": "1.1.0"
+            "anymatch": "^2.0.0",
+            "async-done": "^1.2.0",
+            "chokidar": "^2.0.0",
+            "is-negated-glob": "^1.0.0",
+            "just-debounce": "^1.0.0",
+            "object.defaults": "^1.1.0"
           }
         },
         "gulp-cli": {
@@ -2878,24 +2923,24 @@
           "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
           "dev": true,
           "requires": {
-            "ansi-colors": "1.0.1",
-            "archy": "1.0.0",
-            "array-sort": "1.0.0",
-            "color-support": "1.1.3",
-            "concat-stream": "1.6.0",
-            "copy-props": "2.0.1",
-            "fancy-log": "1.3.2",
-            "gulplog": "1.0.0",
-            "interpret": "1.1.0",
-            "isobject": "3.0.1",
-            "liftoff": "3.1.0",
-            "matchdep": "2.0.0",
-            "mute-stdout": "1.0.0",
-            "pretty-hrtime": "1.0.3",
-            "replace-homedir": "1.0.0",
-            "semver-greatest-satisfied-range": "1.1.0",
-            "v8flags": "3.0.1",
-            "yargs": "7.1.0"
+            "ansi-colors": "^1.0.1",
+            "archy": "^1.0.0",
+            "array-sort": "^1.0.0",
+            "color-support": "^1.1.3",
+            "concat-stream": "^1.6.0",
+            "copy-props": "^2.0.1",
+            "fancy-log": "^1.3.2",
+            "gulplog": "^1.0.0",
+            "interpret": "^1.1.0",
+            "isobject": "^3.0.1",
+            "liftoff": "^3.1.0",
+            "matchdep": "^2.0.0",
+            "mute-stdout": "^1.0.0",
+            "pretty-hrtime": "^1.0.0",
+            "replace-homedir": "^1.0.0",
+            "semver-greatest-satisfied-range": "^1.1.0",
+            "v8flags": "^3.0.1",
+            "yargs": "^7.1.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -2904,7 +2949,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "liftoff": {
@@ -2913,14 +2958,14 @@
           "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
           "dev": true,
           "requires": {
-            "extend": "3.0.1",
-            "findup-sync": "3.0.0",
-            "fined": "1.1.0",
-            "flagged-respawn": "1.0.0",
-            "is-plain-object": "2.0.4",
-            "object.map": "1.0.1",
-            "rechoir": "0.6.2",
-            "resolve": "1.5.0"
+            "extend": "^3.0.0",
+            "findup-sync": "^3.0.0",
+            "fined": "^1.0.1",
+            "flagged-respawn": "^1.0.0",
+            "is-plain-object": "^2.0.4",
+            "object.map": "^1.0.0",
+            "rechoir": "^0.6.2",
+            "resolve": "^1.1.7"
           }
         },
         "string-width": {
@@ -2929,9 +2974,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -2940,7 +2985,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "undertaker": {
@@ -2949,15 +2994,15 @@
           "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "arr-map": "2.0.2",
-            "bach": "1.2.0",
-            "collection-map": "1.0.0",
-            "es6-weak-map": "2.0.2",
-            "last-run": "1.1.1",
-            "object.defaults": "1.1.0",
-            "object.reduce": "1.0.1",
-            "undertaker-registry": "1.0.1"
+            "arr-flatten": "^1.0.1",
+            "arr-map": "^2.0.0",
+            "bach": "^1.0.0",
+            "collection-map": "^1.0.0",
+            "es6-weak-map": "^2.0.1",
+            "last-run": "^1.1.0",
+            "object.defaults": "^1.0.0",
+            "object.reduce": "^1.0.0",
+            "undertaker-registry": "^1.0.0"
           }
         },
         "yargs": {
@@ -2966,19 +3011,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         }
       }
@@ -2989,9 +3034,9 @@
       "integrity": "sha512-9GUqCqh85C7rP9120cpxXuZz2ayq3BZc85pCTuPJS03VQYxne0aWPIXWx6LSvsGPa3uRqtSO537vaugOh+5cXg==",
       "dev": true,
       "requires": {
-        "eslint": "5.16.0",
-        "fancy-log": "1.3.2",
-        "plugin-error": "1.0.1"
+        "eslint": "^5.0.1",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^1.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3000,8 +3045,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-extendable": {
@@ -3010,7 +3055,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "plugin-error": {
@@ -3019,10 +3064,10 @@
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "dev": true,
           "requires": {
-            "ansi-colors": "1.0.1",
-            "arr-diff": "4.0.0",
-            "arr-union": "3.1.0",
-            "extend-shallow": "3.0.2"
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
           }
         }
       }
@@ -3033,12 +3078,12 @@
       "integrity": "sha512-uMLSdqPDnBAV/B9rNyOgVMgrVC1tPbe+5GH6P13UOyxbRDT/w4sKYHWftPMA8j9om+NFvfeRlqpDXL2fixFWNA==",
       "dev": true,
       "requires": {
-        "istanbul": "0.4.5",
-        "istanbul-threshold-checker": "0.2.1",
-        "lodash": "4.17.4",
-        "plugin-error": "0.1.2",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "istanbul": "^0.4.0",
+        "istanbul-threshold-checker": "^0.2.1",
+        "lodash": "^4.0.0",
+        "plugin-error": "^0.1.2",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.1"
       }
     },
     "gulp-mocha": {
@@ -3047,13 +3092,13 @@
       "integrity": "sha512-FfBldW5ttnDpKf4Sg6/BLOOKCCbr5mbixDGK1t02/8oSrTCwNhgN/mdszG3cuQuYNzuouUdw4EH/mlYtgUscPg==",
       "dev": true,
       "requires": {
-        "dargs": "5.1.0",
-        "execa": "0.10.0",
-        "mocha": "5.2.0",
-        "npm-run-path": "2.0.2",
-        "plugin-error": "1.0.1",
-        "supports-color": "5.5.0",
-        "through2": "2.0.3"
+        "dargs": "^5.1.0",
+        "execa": "^0.10.0",
+        "mocha": "^5.2.0",
+        "npm-run-path": "^2.0.2",
+        "plugin-error": "^1.0.1",
+        "supports-color": "^5.4.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "browser-stdout": {
@@ -3080,8 +3125,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "growl": {
@@ -3102,7 +3147,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "mocha": {
@@ -3130,7 +3175,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -3141,10 +3186,10 @@
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "dev": true,
           "requires": {
-            "ansi-colors": "1.0.1",
-            "arr-diff": "4.0.0",
-            "arr-union": "3.1.0",
-            "extend-shallow": "3.0.2"
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
           }
         }
       }
@@ -3155,7 +3200,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "^1.0.0"
       }
     },
     "handlebars": {
@@ -3164,10 +3209,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "source-map": {
@@ -3176,7 +3221,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -3193,8 +3238,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "6.9.1",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -3203,7 +3248,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -3224,9 +3269,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -3235,8 +3280,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3245,7 +3290,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3262,7 +3307,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -3277,9 +3322,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.16.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -3288,7 +3333,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -3303,8 +3348,8 @@
       "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
       "dev": true,
       "requires": {
-        "parent-module": "1.0.1",
-        "resolve-from": "4.0.0"
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       }
     },
     "imurmurhash": {
@@ -3325,8 +3370,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3347,19 +3392,19 @@
       "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "3.0.3",
-        "figures": "2.0.0",
-        "lodash": "4.17.11",
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "6.5.1",
-        "string-width": "2.1.1",
-        "strip-ansi": "5.2.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3374,9 +3419,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "lodash": {
@@ -3391,7 +3436,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -3414,8 +3459,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "1.0.0",
-        "is-windows": "1.0.1"
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
       }
     },
     "is-accessor-descriptor": {
@@ -3424,7 +3469,7 @@
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.0"
       }
     },
     "is-arrayish": {
@@ -3439,7 +3484,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -3454,7 +3499,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -3469,7 +3514,7 @@
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.0"
       }
     },
     "is-date-object": {
@@ -3484,9 +3529,9 @@
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
       }
     },
     "is-extendable": {
@@ -3513,7 +3558,7 @@
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-negated-glob": {
@@ -3528,7 +3573,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3537,7 +3582,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3548,7 +3593,7 @@
       "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "^3.0.0"
       }
     },
     "is-plain-object": {
@@ -3557,7 +3602,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -3572,7 +3617,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-relative": {
@@ -3581,7 +3626,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "1.0.0"
+        "is-unc-path": "^1.0.0"
       }
     },
     "is-stream": {
@@ -3596,7 +3641,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -3611,7 +3656,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.2"
       }
     },
     "is-utf8": {
@@ -3668,20 +3713,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -3696,11 +3741,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -3721,7 +3766,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -3732,8 +3777,8 @@
       "integrity": "sha1-xdyU6PLMXNP/0zVFL4S1U8QkgzE=",
       "dev": true,
       "requires": {
-        "istanbul": "0.4.5",
-        "lodash": "4.17.4"
+        "istanbul": "~0.4.5",
+        "lodash": "~4.17.2"
       }
     },
     "js-tokens": {
@@ -3748,8 +3793,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -3776,7 +3821,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -3827,8 +3872,8 @@
       "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
       "dev": true,
       "requires": {
-        "default-resolution": "2.0.0",
-        "es6-weak-map": "2.0.2"
+        "default-resolution": "^2.0.0",
+        "es6-weak-map": "^2.0.1"
       }
     },
     "lazy-cache": {
@@ -3837,7 +3882,7 @@
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "dev": true,
       "requires": {
-        "set-getter": "0.1.0"
+        "set-getter": "^0.1.0"
       }
     },
     "lazystream": {
@@ -3846,7 +3891,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "lcid": {
@@ -3855,7 +3900,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -3870,7 +3915,7 @@
       "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
       "dev": true,
       "requires": {
-        "flush-write-stream": "1.0.2"
+        "flush-write-stream": "^1.0.2"
       }
     },
     "levn": {
@@ -3879,8 +3924,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -3889,11 +3934,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "locate-path": {
@@ -3902,8 +3947,8 @@
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "3.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -3932,14 +3977,15 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1"
+        "chalk": "^2.0.1"
       }
     },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "make-iterator": {
       "version": "1.0.0",
@@ -3947,7 +3993,7 @@
       "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3956,7 +4002,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3967,7 +4013,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "1.0.0"
+        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -3982,7 +4028,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "matchdep": {
@@ -3991,9 +4037,9 @@
       "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
       "dev": true,
       "requires": {
-        "findup-sync": "2.0.0",
-        "micromatch": "3.1.5",
-        "resolve": "1.5.0",
+        "findup-sync": "^2.0.0",
+        "micromatch": "^3.0.4",
+        "resolve": "^1.4.0",
         "stack-trace": "0.0.10"
       }
     },
@@ -4003,9 +4049,9 @@
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "0.1.3",
-        "mimic-fn": "2.1.0",
-        "p-is-promise": "2.1.0"
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -4022,19 +4068,19 @@
       "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.0",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.7",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.0",
+        "define-property": "^1.0.0",
+        "extend-shallow": "^2.0.1",
+        "extglob": "^2.0.2",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.0",
+        "nanomatch": "^1.2.5",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "mime-db": {
@@ -4049,7 +4095,7 @@
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "dev": true,
       "requires": {
-        "mime-db": "1.38.0"
+        "mime-db": "~1.38.0"
       }
     },
     "mimic-fn": {
@@ -4064,7 +4110,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4079,8 +4125,8 @@
       "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4089,7 +4135,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -4166,9 +4212,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -4177,8 +4223,8 @@
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               }
             }
           }
@@ -4189,7 +4235,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "execa": {
@@ -4198,13 +4244,13 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "find-up": {
@@ -4213,7 +4259,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-caller-file": {
@@ -4228,7 +4274,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "glob": {
@@ -4237,12 +4283,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "he": {
@@ -4263,8 +4309,8 @@
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "lcid": {
@@ -4273,7 +4319,7 @@
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
-            "invert-kv": "2.0.0"
+            "invert-kv": "^2.0.0"
           }
         },
         "ms": {
@@ -4288,9 +4334,9 @@
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
-            "execa": "1.0.0",
-            "lcid": "2.0.0",
-            "mem": "4.3.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
         },
         "pump": {
@@ -4299,8 +4345,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "require-main-filename": {
@@ -4315,9 +4361,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -4326,7 +4372,7 @@
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
-                "ansi-regex": "4.1.0"
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -4337,7 +4383,7 @@
           "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "which": {
@@ -4346,7 +4392,7 @@
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -4367,17 +4413,17 @@
           "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "2.0.5",
-            "os-locale": "3.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "3.1.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "13.0.0"
+            "cliui": "^4.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.0.0"
           }
         },
         "yargs-parser": {
@@ -4386,8 +4432,8 @@
           "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -4423,17 +4469,17 @@
       "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "is-odd": "1.0.0",
-        "kind-of": "5.1.0",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^1.0.0",
+        "kind-of": "^5.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -4462,8 +4508,8 @@
       "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
       "dev": true,
       "requires": {
-        "object.getownpropertydescriptors": "2.0.3",
-        "semver": "5.7.0"
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
       },
       "dependencies": {
         "semver": {
@@ -4480,7 +4526,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -4489,10 +4535,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -4501,7 +4547,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "now-and-later": {
@@ -4510,7 +4556,7 @@
       "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.2"
       }
     },
     "npm-run-path": {
@@ -4519,7 +4565,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -4540,9 +4586,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -4551,7 +4597,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -4560,7 +4606,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4569,7 +4615,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-descriptor": {
@@ -4578,9 +4624,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -4597,7 +4643,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4614,7 +4660,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.assign": {
@@ -4623,10 +4669,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.defaults": {
@@ -4635,10 +4681,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "1.0.1",
-        "array-slice": "1.1.0",
-        "for-own": "1.0.0",
-        "isobject": "3.0.1"
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "object.getownpropertydescriptors": {
@@ -4647,8 +4693,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.13.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.map": {
@@ -4657,8 +4703,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "1.0.0",
-        "make-iterator": "1.0.0"
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
       }
     },
     "object.pick": {
@@ -4667,7 +4713,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "object.reduce": {
@@ -4676,8 +4722,8 @@
       "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
       "dev": true,
       "requires": {
-        "for-own": "1.0.0",
-        "make-iterator": "1.0.0"
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
       }
     },
     "once": {
@@ -4686,7 +4732,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -4695,7 +4741,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -4704,8 +4750,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -4728,12 +4774,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "ordered-read-streams": {
@@ -4742,7 +4788,7 @@
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "os-locale": {
@@ -4751,7 +4797,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -4784,7 +4830,7 @@
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "dev": true,
       "requires": {
-        "p-try": "2.2.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -4793,7 +4839,7 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "2.2.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-try": {
@@ -4808,7 +4854,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
-        "callsites": "3.1.0"
+        "callsites": "^3.0.0"
       }
     },
     "parse-code-context": {
@@ -4823,12 +4869,12 @@
       "integrity": "sha1-aMlV8eybZVpPJBsRJMedsTENZ70=",
       "dev": true,
       "requires": {
-        "arrayify-compact": "0.1.0",
-        "extract-comments": "0.7.3",
-        "gfm-code-blocks": "0.2.2",
-        "inflection": "1.12.0",
-        "lodash": "3.10.1",
-        "parse-code-context": "0.1.3"
+        "arrayify-compact": "^0.1.0",
+        "extract-comments": "^0.7.3",
+        "gfm-code-blocks": "^0.2.0",
+        "inflection": "^1.7.0",
+        "lodash": "^3.6.0",
+        "parse-code-context": "^0.1.3"
       },
       "dependencies": {
         "lodash": {
@@ -4845,9 +4891,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "1.0.0",
-        "map-cache": "0.2.2",
-        "path-root": "0.1.1"
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
       }
     },
     "parse-json": {
@@ -4856,7 +4902,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -4883,7 +4929,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -4916,7 +4962,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "0.1.2"
+        "path-root-regex": "^0.1.0"
       }
     },
     "path-root-regex": {
@@ -4931,9 +4977,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pathval": {
@@ -4966,7 +5012,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "plugin-error": {
@@ -4975,11 +5021,11 @@
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "dev": true,
       "requires": {
-        "ansi-cyan": "0.1.1",
-        "ansi-red": "0.1.1",
-        "arr-diff": "1.1.0",
-        "arr-union": "2.1.0",
-        "extend-shallow": "1.1.4"
+        "ansi-cyan": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "arr-diff": "^1.0.1",
+        "arr-union": "^2.0.1",
+        "extend-shallow": "^1.1.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -4988,8 +5034,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-slice": "0.2.3"
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
           }
         },
         "arr-union": {
@@ -5010,7 +5056,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -5063,8 +5109,8 @@
       "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -5073,9 +5119,9 @@
       "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.3",
-        "inherits": "2.0.3",
-        "pump": "2.0.0"
+        "duplexify": "^3.5.3",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -5096,9 +5142,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -5107,8 +5153,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -5117,13 +5163,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -5132,10 +5178,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "rechoir": {
@@ -5144,7 +5190,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "regex-not": {
@@ -5153,7 +5199,7 @@
       "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "regexpp": {
@@ -5168,8 +5214,8 @@
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6",
-        "is-utf8": "0.2.1"
+        "is-buffer": "^1.1.5",
+        "is-utf8": "^0.2.1"
       }
     },
     "remove-bom-stream": {
@@ -5178,9 +5224,9 @@
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
       "dev": true,
       "requires": {
-        "remove-bom-buffer": "3.0.0",
-        "safe-buffer": "5.1.1",
-        "through2": "2.0.3"
+        "remove-bom-buffer": "^3.0.0",
+        "safe-buffer": "^5.1.0",
+        "through2": "^2.0.3"
       }
     },
     "remove-trailing-separator": {
@@ -5213,9 +5259,9 @@
       "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1",
-        "is-absolute": "1.0.0",
-        "remove-trailing-separator": "1.1.0"
+        "homedir-polyfill": "^1.0.1",
+        "is-absolute": "^1.0.0",
+        "remove-trailing-separator": "^1.1.0"
       }
     },
     "request": {
@@ -5224,26 +5270,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.7",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.22",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "extend": {
@@ -5278,7 +5324,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -5287,8 +5333,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -5303,7 +5349,7 @@
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
       "dev": true,
       "requires": {
-        "value-or-function": "3.0.0"
+        "value-or-function": "^3.0.0"
       }
     },
     "resolve-url": {
@@ -5318,8 +5364,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "right-align": {
@@ -5329,7 +5375,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -5338,7 +5384,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "7.1.4"
+        "glob": "^7.1.3"
       },
       "dependencies": {
         "glob": {
@@ -5347,12 +5393,12 @@
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -5363,7 +5409,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
@@ -5372,7 +5418,7 @@
       "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -5399,7 +5445,7 @@
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
       "dev": true,
       "requires": {
-        "sver-compat": "1.5.0"
+        "sver-compat": "^1.5.0"
       }
     },
     "set-blocking": {
@@ -5414,7 +5460,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -5429,10 +5475,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       }
     },
     "shebang-command": {
@@ -5441,7 +5487,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -5456,9 +5502,9 @@
       "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shelljs-nodecli": {
@@ -5467,7 +5513,7 @@
       "integrity": "sha1-8b61VjdUxHXQb30IM+D2B15GLTs=",
       "dev": true,
       "requires": {
-        "shelljs": "0.2.6"
+        "shelljs": "~0.2"
       },
       "dependencies": {
         "shelljs": {
@@ -5490,9 +5536,9 @@
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "astral-regex": "1.0.0",
-        "is-fullwidth-code-point": "2.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "snapdragon": {
@@ -5501,14 +5547,14 @@
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -5526,7 +5572,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -5535,7 +5581,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5544,7 +5590,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5555,7 +5601,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5564,7 +5610,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5575,9 +5621,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -5594,9 +5640,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       }
     },
     "snapdragon-util": {
@@ -5605,7 +5651,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -5614,7 +5660,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5631,11 +5677,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "2.0.3",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.0.0",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -5656,7 +5702,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -5677,7 +5723,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5686,8 +5732,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-extendable": {
@@ -5696,7 +5742,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -5713,15 +5759,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-trace": {
@@ -5736,8 +5782,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -5746,7 +5792,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -5755,7 +5801,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5764,7 +5810,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5775,7 +5821,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5784,7 +5830,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5795,9 +5841,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -5826,8 +5872,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string_decoder": {
@@ -5836,7 +5882,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -5845,7 +5891,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5862,7 +5908,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-eof": {
@@ -5883,7 +5929,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -5900,8 +5946,8 @@
       "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "table": {
@@ -5910,10 +5956,10 @@
       "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
       "dev": true,
       "requires": {
-        "ajv": "6.9.1",
-        "lodash": "4.17.11",
-        "slice-ansi": "2.1.0",
-        "string-width": "3.1.0"
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5934,9 +5980,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -5945,7 +5991,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -5968,8 +6014,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "through2-filter": {
@@ -5978,8 +6024,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "time-stamp": {
@@ -5994,7 +6040,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -6003,8 +6049,8 @@
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "requires": {
-        "is-absolute": "1.0.0",
-        "is-negated-glob": "1.0.0"
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
       }
     },
     "to-object-path": {
@@ -6013,7 +6059,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6022,7 +6068,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6033,9 +6079,9 @@
       "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^1.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -6044,7 +6090,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -6053,7 +6099,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6062,7 +6108,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6073,7 +6119,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6082,7 +6128,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6093,9 +6139,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -6112,8 +6158,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "to-through": {
@@ -6122,7 +6168,7 @@
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.3"
       }
     },
     "tough-cookie": {
@@ -6131,8 +6177,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "1.1.31",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       }
     },
     "tslib": {
@@ -6147,7 +6193,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -6162,7 +6208,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -6184,9 +6230,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -6214,10 +6260,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "set-value": {
@@ -6226,10 +6272,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -6240,8 +6286,8 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "1.0.1",
-        "through2-filter": "2.0.0"
+        "json-stable-stringify": "^1.0.0",
+        "through2-filter": "^2.0.0"
       }
     },
     "unset-value": {
@@ -6250,8 +6296,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -6260,9 +6306,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -6290,7 +6336,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -6313,9 +6359,9 @@
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -6324,7 +6370,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -6333,7 +6379,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6342,7 +6388,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6353,7 +6399,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6362,7 +6408,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6373,9 +6419,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -6404,7 +6450,7 @@
       "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "validate-npm-package-license": {
@@ -6413,8 +6459,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "value-or-function": {
@@ -6429,9 +6475,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vinyl": {
@@ -6440,12 +6486,12 @@
       "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
       "dev": true,
       "requires": {
-        "clone": "2.1.1",
-        "clone-buffer": "1.0.0",
-        "clone-stats": "1.0.0",
-        "cloneable-readable": "1.0.0",
-        "remove-trailing-separator": "1.1.0",
-        "replace-ext": "1.0.0"
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
       }
     },
     "vinyl-fs": {
@@ -6454,23 +6500,23 @@
       "integrity": "sha1-dK9faDahz0FNNe6zwQ8uZfwqLBA=",
       "dev": true,
       "requires": {
-        "flush-write-stream": "1.0.2",
-        "fs-mkdirp-stream": "1.0.0",
-        "glob-stream": "6.1.0",
-        "graceful-fs": "4.1.11",
-        "is-valid-glob": "1.0.0",
-        "lazystream": "1.0.0",
-        "lead": "1.0.0",
-        "object.assign": "4.1.0",
-        "pumpify": "1.4.0",
-        "remove-bom-buffer": "3.0.0",
-        "remove-bom-stream": "1.2.0",
-        "resolve-options": "1.1.0",
-        "through2": "2.0.3",
-        "to-through": "2.0.0",
-        "value-or-function": "3.0.0",
-        "vinyl": "2.1.0",
-        "vinyl-sourcemap": "1.1.0"
+        "flush-write-stream": "^1.0.0",
+        "fs-mkdirp-stream": "^1.0.0",
+        "glob-stream": "^6.1.0",
+        "graceful-fs": "^4.0.0",
+        "is-valid-glob": "^1.0.0",
+        "lazystream": "^1.0.0",
+        "lead": "^1.0.0",
+        "object.assign": "^4.0.4",
+        "pumpify": "^1.3.5",
+        "remove-bom-buffer": "^3.0.0",
+        "remove-bom-stream": "^1.2.0",
+        "resolve-options": "^1.1.0",
+        "through2": "^2.0.0",
+        "to-through": "^2.0.0",
+        "value-or-function": "^3.0.0",
+        "vinyl": "^2.0.0",
+        "vinyl-sourcemap": "^1.1.0"
       }
     },
     "vinyl-sourcemap": {
@@ -6479,13 +6525,13 @@
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
       "dev": true,
       "requires": {
-        "append-buffer": "1.0.2",
-        "convert-source-map": "1.5.1",
-        "graceful-fs": "4.1.11",
-        "normalize-path": "2.1.1",
-        "now-and-later": "2.0.0",
-        "remove-bom-buffer": "3.0.0",
-        "vinyl": "2.1.0"
+        "append-buffer": "^1.0.2",
+        "convert-source-map": "^1.5.0",
+        "graceful-fs": "^4.1.6",
+        "normalize-path": "^2.1.1",
+        "now-and-later": "^2.0.0",
+        "remove-bom-buffer": "^3.0.0",
+        "vinyl": "^2.0.0"
       }
     },
     "vinyl-sourcemaps-apply": {
@@ -6494,7 +6540,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.1"
       }
     },
     "which": {
@@ -6503,7 +6549,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -6518,7 +6564,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "window-size": {
@@ -6540,8 +6586,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -6550,7 +6596,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -6559,9 +6605,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -6570,7 +6616,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -6587,7 +6633,7 @@
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "xtend": {
@@ -6609,9 +6655,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -6621,7 +6667,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -6638,9 +6684,9 @@
       "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
       "dev": true,
       "requires": {
-        "flat": "4.1.0",
-        "lodash": "4.17.11",
-        "yargs": "12.0.5"
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
       },
       "dependencies": {
         "camelcase": {
@@ -6655,9 +6701,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "execa": {
@@ -6666,13 +6712,13 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "find-up": {
@@ -6681,7 +6727,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-stream": {
@@ -6690,7 +6736,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "invert-kv": {
@@ -6705,7 +6751,7 @@
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
-            "invert-kv": "2.0.0"
+            "invert-kv": "^2.0.0"
           }
         },
         "lodash": {
@@ -6720,9 +6766,9 @@
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
-            "execa": "1.0.0",
-            "lcid": "2.0.0",
-            "mem": "4.3.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
         },
         "pump": {
@@ -6731,8 +6777,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "which-module": {
@@ -6747,18 +6793,18 @@
           "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "3.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "11.1.1"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
@@ -6767,8 +6813,8 @@
           "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }

--- a/rules/di.js
+++ b/rules/di.js
@@ -33,6 +33,9 @@ module.exports = {
                 },
                 stripUnderscores: {
                     type: 'boolean'
+                },
+                allowCamelCaseMatch: {
+                    type: 'boolean'
                 }
             }
         }]
@@ -43,6 +46,7 @@ module.exports = {
         var extra = context.options[1] || {};
         var matchNames = extra.matchNames !== false;
         var stripUnderscores = extra.stripUnderscores === true;
+        var allowCamelCaseMatch = extra.allowCamelCaseMatch === true;
 
         function report(node) {
             context.report(node, 'You should use the {{syntax}} syntax for DI', {
@@ -86,6 +90,12 @@ module.exports = {
                                 name = normalizeParameter(name);
                             }
 
+                            if (allowCamelCaseMatch) {
+                                var paramName = fn.parent.elements[i].value;
+                                var camelParamName = paramName.substr(0, 1).toLowerCase() + paramName.substr(1);
+                                return name !== paramName && name !== camelParamName;
+                            }
+
                             return name !== fn.parent.elements[i].value;
                         });
                         if (invalidArray.length > 0) {
@@ -123,6 +133,12 @@ module.exports = {
 
                                 if (stripUnderscores) {
                                     name = normalizeParameter(name);
+                                }
+
+                                if (allowCamelCaseMatch) {
+                                    var paramName = $injectArray.elements[i].value;
+                                    var camelParamName = paramName.substr(0, 1).toLowerCase() + paramName.substr(1);
+                                    return name !== paramName && name !== camelParamName;
                                 }
 
                                 return name !== $injectArray.elements[i].value;

--- a/test/di.js
+++ b/test/di.js
@@ -139,6 +139,9 @@ angularNamedObjectList.forEach(function(object) {
         code: 'angular.module("myModule").' + object + '("name", ["Service1", function(Service1) {}]);',
         options: ['array']
     }, {
+        code: 'angular.module("myModule").' + object + '("name", ["MyService", function(myService) {}]);',
+        options: ['array', {matchNames: true, allowCamelCaseMatch: true}]
+    }, {
         code: 'angular.module("myModule").' + object + '("name", myFunction);function MyFunction() {}',
         options: ['function']
     }, {
@@ -148,11 +151,14 @@ angularNamedObjectList.forEach(function(object) {
         code: 'angular.module("myModule").' + object + '("name", myFunction);myFunction.$inject=["myService"];function myFunction(myService) {}',
         options: ['$inject']
     }, {
+        code: 'angular.module("myModule").' + object + '("name", myFunction);myFunction.$inject=["myService"];function myFunction(myService) {}',
+        options: ['$inject']
+    }, {
         code: 'myFunction.$inject=["myService"];function myFunction(myService) {} angular.module("myModule").' + object + '("name", myFunction);',
         options: ['$inject']
     }, {
-        code: 'function myFunction(myService) {} myFunction.$inject=["myService"];angular.module("myModule").' + object + '("name", myFunction);',
-        options: ['$inject']
+        code: 'function myFunction(myService) {} myFunction.$inject=["MyService"];angular.module("myModule").' + object + '("name", myFunction);',
+        options: ['$inject', {matchNames: true, allowCamelCaseMatch: true}]
     }, {
         code: 'var myFunction = function(myService) {}; myFunction.$inject=["myService"];angular.module("myModule").' + object + '("name", myFunction);',
         options: ['$inject']
@@ -199,6 +205,10 @@ angularNamedObjectList.forEach(function(object) {
         options: ['$inject'],
         errors: [{message: 'You have an error in your DI configuration. Each items of the array should match exactly one function parameter'}]
     }, {
+        code: 'function myFunction(myService) {} myFunction.$inject=["myservice"];angular.module("myModule").' + object + '("name", myFunction);',
+        options: ['$inject', {matchNames: true, allowCamelCaseMatch: true}],
+        errors: [{message: 'You have an error in your DI configuration. Each items of the array should match exactly one function parameter'}]
+    }, {
         code: 'angular.module("myModule").' + object + '("name", ["$urlRouteProvider", function($urlRouteProvider, $timeout){}])',
         options: ['array'],
         errors: [{message: 'The signature of the method is incorrect'}]
@@ -209,6 +219,10 @@ angularNamedObjectList.forEach(function(object) {
     }, {
         code: 'angular.module("myModule").' + object + '("name", ["$urlRouteProvider", "$timeout", function($timeout, $urlRouteProvider){}])',
         options: ['array'],
+        errors: [{message: 'You have an error in your DI configuration. Each items of the array should match exactly one function parameter'}]
+    }, {
+        code: 'angular.module("myModule").' + object + '("name", ["MyService", function(myservice){}])',
+        options: ['array', {matchNames: true, allowCamelCaseMatch: true}],
         errors: [{message: 'You have an error in your DI configuration. Each items of the array should match exactly one function parameter'}]
     });
 });


### PR DESCRIPTION
Our rules have been to PascalCase services and factories, but the JavaScript rule is to have variables camelCase.

To allow for this, we need to be able to $inject = ["MyService"] as (myService).

I added an allowCamelCaseMatch option to pair with matchNames to allow for this.

- Code was added
- Tests were added / ran
- Quality was checked (no tabs vs spaces this time!)
- Documentation was updated

Please consider merging this PR into your master branch.